### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,8 +19,8 @@ skip	KEYWORD2
 search_init	KEYWORD2
 search	KEYWORD2
 crc8	KEYWORD2
-crcbit  KEYWORD2
-readRM  KEYWORD2
+crcbit	KEYWORD2
+readRM	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords